### PR TITLE
fix: support sub configuration to be immutable to

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint": "^8.56.0",
         "husky": "^4.3.5",
         "jest": "^29.7.0",
+        "jest-extended": "^4.0.2",
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.0",
         "prom-client": "^15.0.0",
@@ -8147,6 +8148,28 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-extended": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-4.0.2.tgz",
+      "integrity": "sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-diff": "^29.0.0",
+        "jest-get-type": "^29.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=27.2.5"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "pretty-quick": "^3.1.0",
     "ts-jest": "^29.1.5",
     "typescript": "^5.4.5",
-    "prom-client": "^15.0.0"
+    "prom-client": "^15.0.0",
+    "jest-extended": "^4.0.2"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ import { createDebug } from './utils/debug';
 import { LOCAL_SCHEMAS_PACKAGE_VERSION } from './constants';
 import { createConfigError } from './errors';
 import { initializeMetrics as initializeMetricsInternal } from './metrics';
+import { deepFreeze } from './utils/helpers';
 
 const debug = createDebug('config');
 
@@ -101,7 +102,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
 
   debug('freezing validated config');
   // freeze the merged config so it can't be modified by the package user
-  Object.freeze(validatedConfig);
+  deepFreeze(validatedConfig);
 
   function get<TPath extends string>(path: TPath): GetFieldType<T[typeof typeSymbol], TPath> {
     debug('get called with path: %s', path);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,10 @@
+export function deepFreeze<T>(obj: T): void {
+  const propNames = Object.getOwnPropertyNames(obj);
+  for (const name of propNames) {
+    const value = obj[name as keyof T];
+    if (typeof value === 'object') {
+      deepFreeze(value);
+    }
+  }
+  Object.freeze(obj);
+}

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest-extended" />
 import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
 import { commonDbPartialV1, commonS3PartialV1 } from '@map-colonies/schemas';
 import { StatusCodes } from 'http-status-codes';
@@ -40,7 +41,6 @@ describe('config', () => {
       });
 
       const conf = configInstance.getAll();
-
       expect(conf).toEqual({
         host: 'avi',
         port: 5432,
@@ -302,6 +302,34 @@ describe('config', () => {
       });
 
       await expect(promise).rejects.toThrow();
+    });
+
+    it('should returned on getAll() a full frozen configuration object ', async () => {
+      const configInstance = await config({
+        configName: 'name',
+        version: 1,
+        schema: commonDbPartialV1,
+        configServerUrl: URL,
+        localConfigPath: './tests/config',
+        offlineMode: true,
+      });
+
+      const conf = configInstance.getAll();
+      expect(conf).toBeFrozen();
+    });
+
+    it('should returned on get(`ssl`) a frozen sub configuration object ', async () => {
+      const configInstance = await config({
+        configName: 'name',
+        version: 1,
+        schema: commonDbPartialV1,
+        configServerUrl: URL,
+        localConfigPath: './tests/config',
+        offlineMode: true,
+      });
+
+      const conf = configInstance.get('ssl');
+      expect(conf).toBeFrozen();
     });
   });
 });

--- a/tests/configurations/jest.config.js
+++ b/tests/configurations/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   coverageDirectory: '<rootDir>/coverage',
   rootDir: '../../.',
   testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  setupFilesAfterEnv: ['jest-extended/all'],
   // setupFiles: ['<rootDir>/tests/configurations/jest.setup.ts'],
   // setupFiles: ['<rootDir>/tests/configurations/afterEnv.setup.ts'],
   // reporters: [


### PR DESCRIPTION
implement deepFreeze method based on Object. freeze()

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                  |
| Chore            | ✖                                                                       |

closes #18 
Users can't modify the object, not the root, and not the children