### PR TITLE
fix: support null valued config attributes

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,7 +2,7 @@ export function deepFreeze<T>(obj: T): void {
   const propNames = Object.getOwnPropertyNames(obj);
   for (const name of propNames) {
     const value = obj[name as keyof T];
-    if (typeof value === 'object') {
+    if (typeof value === 'object' && value !== null) {
       deepFreeze(value);
     }
   }

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -1,0 +1,35 @@
+import { deepFreeze } from '../src/utils/helpers';
+
+describe('helpers', () => {
+  describe('#deepFreeze', () => {
+    it('should return object freeze', () => {
+      const data = {
+        name: 'I am parent',
+        child: {
+          name: 'I am child',
+        },
+      };
+      deepFreeze(data);
+
+      const action = () => {
+        data.name = 'i try to change'; // try to change freezed object
+      };
+      expect(action).toThrow(/Cannot assign to read only property/);
+    });
+
+    it('should return object freeze with null value', () => {
+      const data = {
+        name: 'I am parent',
+        child: {
+          name: null,
+        },
+      };
+      deepFreeze(data);
+
+      const action = () => {
+        data.name = 'i try to change'; // try to change freezed object
+      };
+      expect(action).toThrow(/Cannot assign to read only property/);
+    });
+  });
+});

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -2,7 +2,7 @@ import { deepFreeze } from '../src/utils/helpers';
 
 describe('helpers', () => {
   describe('#deepFreeze', () => {
-    it('should return object freeze', () => {
+    it('should return frozen object', () => {
       const data = {
         name: 'I am parent',
         child: {
@@ -17,7 +17,7 @@ describe('helpers', () => {
       expect(action).toThrow(/Cannot assign to read only property/);
     });
 
-    it('should return object freeze with null value', () => {
+    it('should return frozen object with nested null value without error', () => {
       const data = {
         name: 'I am parent',
         child: {

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -1,3 +1,4 @@
+import 'jest-extended';
 import { deepFreeze } from '../src/utils/helpers';
 
 describe('helpers', () => {
@@ -9,27 +10,34 @@ describe('helpers', () => {
           name: 'I am child',
         },
       };
-      deepFreeze(data);
 
-      const action = () => {
-        data.name = 'i try to change'; // try to change freezed object
-      };
-      expect(action).toThrow(/Cannot assign to read only property/);
+      deepFreeze(data);
+      expect(data).toBeFrozen();
     });
 
-    it('should return frozen object with nested null value without error', () => {
+    it('should freeze the input object that include null valued property without error', () => {
+      const data = {
+        name: null,
+        child: {
+          name: 'i am child',
+        },
+      };
+
+      deepFreeze(data);
+      expect(data).toBeFrozen();
+    });
+
+    it('should freeze the input object include nested property', () => {
       const data = {
         name: 'I am parent',
         child: {
-          name: null,
+          name: 'I am child',
         },
       };
-      deepFreeze(data);
 
-      const action = () => {
-        data.name = 'i try to change'; // try to change freezed object
-      };
-      expect(action).toThrow(/Cannot assign to read only property/);
+      deepFreeze(data);
+      const child = data.child;
+      expect(child).toBeFrozen();
     });
   });
 });


### PR DESCRIPTION
deepFreeze couldn't support with null valued attributes.

Added null validation on freeze objects

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                       |
| Chore            | ✖                                                                       |
