### PR TITLE
feat: added a check for valid server version for the package

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,7 @@ const configErrors = {
   schemasPackageVersionMismatchError: { code: 6, payload: {} as { remotePackageVersion: string; localPackageVersion: string } },
   schemaVersionMismatchError: { code: 7, payload: {} as { remoteSchemaVersion: string; localSchemaVersion: string } },
   promClientNotInstalledError: { code: 8, payload: {} as { message: string } },
+  serverVersionMismatchError: { code: 9, payload: {} as { remoteServerVersion: string; localServerVersion: string; satisfies: string } },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as const satisfies Record<string, { code: number; payload: any }>;
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -353,5 +353,21 @@ describe('config', () => {
       };
       expect(action).toThrow(/Cannot assign to read only property/);
     });
+
+    it('should throw an error if the server version does not satisfy the required version', async () => {
+      client
+        .intercept({ path: '/capabilities', method: 'GET' })
+        .reply(StatusCodes.OK, { serverVersion: '0.0.1', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+
+      const promise = config({
+        configName: 'name',
+        version: 1,
+        schema: commonDbPartialV1,
+        configServerUrl: URL,
+        localConfigPath: './tests/config',
+      });
+
+      await expect(promise).rejects.toThrow('The server version does not satisfy the required version.');
+    });
   });
 });


### PR DESCRIPTION
This pull request introduces a new validation to ensure the server version satisfies a required semantic version range. It adds functionality for version checking, updates the error-handling mechanism, and includes a corresponding unit test.

### New server version validation:

* **Version check added in `src/config.ts`:**
  - Imported the `satisfies` function from `semver` and defined a required version range (`semverSatisfies`) as `'1.x'`. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L4-R4) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R23)
  - Added a check to validate if the server version satisfies the required range. If not, it throws a `serverVersionMismatchError` with relevant details.

### Error handling enhancements:

* **New error type in `src/errors.ts`:**
  - Added `serverVersionMismatchError` with a unique code and payload structure to handle server version mismatch scenarios.

### Test coverage:

* **Unit test in `tests/config.spec.ts`:**
  - Added a test case to verify that the configuration function throws an appropriate error when the server version does not meet the required version range.