### PR TITLE
fix: set the proper schema query according to config-server

### DIFF
--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -38,7 +38,7 @@ export async function getRemoteConfig(configName: string, schemaId: string, vers
   const { configServerUrl } = getOptions();
   const url = `${configServerUrl}/config/${configName}/${version}`;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const res = await requestWrapper(url, { shouldDereference: true, schema_id: schemaId });
+  const res = await requestWrapper(url, { shouldDereference: true, schemaId });
 
   if (res.statusCode === statusCodes.BAD_REQUEST) {
     debug('Invalid request to getConfig');

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -27,7 +27,7 @@ describe('config', () => {
       };
 
       client
-        .intercept({ path: `/config/name/1?shouldDereference=true&schema_id=${commonDbPartialV1.$id}`, method: 'GET' })
+        .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
         .reply(StatusCodes.OK, configData);
       client
         .intercept({ path: '/capabilities', method: 'GET' })
@@ -112,7 +112,7 @@ describe('config', () => {
       };
 
       client
-        .intercept({ path: `/config/name/1?shouldDereference=true&schema_id=${commonDbPartialV1.$id}`, method: 'GET' })
+        .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
         .reply(StatusCodes.OK, configData);
       client
         .intercept({ path: '/capabilities', method: 'GET' })
@@ -172,7 +172,7 @@ describe('config', () => {
       };
 
       client
-        .intercept({ path: `/config/name/1?shouldDereference=true&schema_id=${commonDbPartialV1.$id}`, method: 'GET' })
+        .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
         .reply(StatusCodes.OK, configData);
       client
         .intercept({ path: '/capabilities', method: 'GET' })
@@ -234,7 +234,7 @@ describe('config', () => {
       };
 
       client
-        .intercept({ path: `/config/name/1?shouldDereference=true&schema_id=${commonS3PartialV1.$id}`, method: 'GET' })
+        .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonS3PartialV1.$id}`, method: 'GET' })
         .reply(StatusCodes.OK, configData);
       client
         .intercept({ path: '/capabilities', method: 'GET' })
@@ -265,7 +265,7 @@ describe('config', () => {
       };
 
       client
-        .intercept({ path: `/config/name/1?shouldDereference=true&schema_id=${commonDbPartialV1.$id}`, method: 'GET' })
+        .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
         .reply(StatusCodes.OK, configData);
       client
         .intercept({ path: '/capabilities', method: 'GET' })

--- a/tests/httpClient.spec.ts
+++ b/tests/httpClient.spec.ts
@@ -58,7 +58,7 @@ describe('httpClient', () => {
         createdAt: 0,
       };
 
-      client.intercept({ path: '/config/name/1?shouldDereference=true&schema_id=schema', method: 'GET' }).reply(StatusCodes.OK, config);
+      client.intercept({ path: '/config/name/1?shouldDereference=true&schemaId=schema', method: 'GET' }).reply(StatusCodes.OK, config);
 
       const result = await getRemoteConfig('name', 'schema', 1);
       expect(result).toEqual(config);
@@ -66,28 +66,28 @@ describe('httpClient', () => {
 
     it('should throw an error if the response is bad request', async () => {
       client
-        .intercept({ path: '/config/name/1?shouldDereference=true&schema_id=schema', method: 'GET' })
+        .intercept({ path: '/config/name/1?shouldDereference=true&schemaId=schema', method: 'GET' })
         .reply(StatusCodes.BAD_REQUEST, 'Bad request');
 
       await expect(getRemoteConfig('name', 'schema', 1)).rejects.toThrow('Invalid request to getConfig');
     });
 
     it('should throw an error if the response is not found', async () => {
-      client.intercept({ path: '/config/name/1?shouldDereference=true&schema_id=schema', method: 'GET' }).reply(StatusCodes.NOT_FOUND, 'Not found');
+      client.intercept({ path: '/config/name/1?shouldDereference=true&schemaId=schema', method: 'GET' }).reply(StatusCodes.NOT_FOUND, 'Not found');
 
       await expect(getRemoteConfig('name', 'schema', 1)).rejects.toThrow('Config with given name and version was not found');
     });
 
     it('should throw an error if the request fails', async () => {
       client
-        .intercept({ path: '/config/name/1?shouldDereference=true&schema_id=schema', method: 'GET' })
+        .intercept({ path: '/config/name/1?shouldDereference=true&schemaId=schema', method: 'GET' })
         .reply(StatusCodes.INTERNAL_SERVER_ERROR, 'Internal Server Error');
 
       await expect(getRemoteConfig('name', 'schema', 1)).rejects.toThrow('Failed to fetch');
     });
 
     it('should throw an error if the request fails to be sent', async () => {
-      client.intercept({ path: '/config/name/1?shouldDereference=true&schema_id=schema', method: 'GET' }).replyWithError(new Error('oh noes'));
+      client.intercept({ path: '/config/name/1?shouldDereference=true&schemaId=schema', method: 'GET' }).replyWithError(new Error('oh noes'));
 
       await expect(getRemoteConfig('name', 'schema', 1)).rejects.toThrow('An error occurred while making the request');
     });


### PR DESCRIPTION
Update the schema query parameter from `schema_id` to `schemaId` in the config requests to align with the configuration server's expected format.