### PR TITLE
feat(hot-reload): poison pill quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The package supports merging configurations from multiple sources (local, remote
 
 1. The remote configuration is fetched from the server specified by the `configServerUrl` option.
 2. If the `version` is set to `'latest'`, the latest version of the configuration is fetched. Otherwise, the specified version is fetched.
-3. **Continuous Polling:** If an `onChange` callback is provided, the SDK continuously polls the server using HTTP ETags (`If-None-Match`). When a `200 OK` is received (indicating a change), the configuration is automatically re-merged, validated, and the callback is triggered. `304 Not Modified` responses are silently ignored.
+3. **Continuous Polling:** If an `onChange` callback is provided, the SDK continuously polls the server using HTTP ETags (`If-None-Match`). When a `200 OK` is received (indicating a change), the configuration is automatically re-merged, validated, and the callback is triggered. `304 Not Modified` responses are silently ignored. To prevent cluster-wide traffic spikes (thundering herd), a **randomized jitter of +/- 15%** is automatically applied to each polling cycle.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ const configInstance = await config({
   configServerUrl: 'http://localhost:8080',
   schema: commonBoilerplateV4,
   version: 'latest',
-  offlineMode: false
+  offlineMode: false,
+  pollIntervalMs: 30000,
+  onChange: (updatedConfig) => {
+    console.log('Configuration updated:', updatedConfig);
+    // Re-initialize DB connections, etc.
+  }
 });
 
 const port = configInstance.get('server.port');
@@ -36,26 +41,26 @@ This section describes the API provided by the package for interacting with the 
 
 ### `ConfigInstance<T>`
 
-The `ConfigInstance` interface represents the your way to interact with the configuration. It provides methods to retrieve configuration values and parts.
+The `ConfigInstance` interface represents your way to interact with the configuration. When hot-reloading is enabled, this instance acts as a **live state machine**, updating its internal state dynamically.
 `T` is the typescript type associated with the chosen schema. it can be imported from the `@map-colonies/schemas` package.
 
 #### Methods
 
 ##### `get<TPath extends string>(path: TPath): _.GetFieldType<T, TPath>`
 
-- **Description**: Retrieves the value at the specified path from the configuration object. Note that the type of returned object is based on the path in the schema.
+- **Description**: Retrieves the value at the specified path from the configuration object. If hot-reloading is active, this returns the value from the **most recent** configuration update.
 - **Parameters**:
   - `path` (`TPath`): The path to the desired value.
 - **Returns**: The value at the specified path.
 
 ##### `getAll(): T`
 
-- **Description**: Retrieves the entire configuration object.
+- **Description**: Retrieves the entire configuration object. If hot-reloading is active, this returns the **most recent** configuration state.
 - **Returns**: The entire configuration object.
 
 ##### `getConfigParts(): { localConfig: object; config: object; envConfig: object }`
 
-- **Description**: Retrieves different parts of the configuration object before being merged and validated. Useful for debugging.
+- **Description**: Retrieves different parts of the configuration object before being merged and validated. If hot-reloading is active, the `config` part reflects the **latest remote payload**.
 - **Returns**: An object containing the `localConfig`, `config`, and `envConfig` parts of the configuration.
   - `localConfig`: The local configuration object.
   - `config`: The remote configuration object.
@@ -121,6 +126,18 @@ This package allows you to configure various options for loading and managing co
 - **Default**: `./config`
 - **Description**: The path to the local configuration folder.
 
+### `pollIntervalMs`
+- **Type**: `number`
+- **Optional**: `true`
+- **Default**: `30000`
+- **Description**: The polling interval in milliseconds for hot-reloading.
+- **Environment Variable**: `CONFIG_POLL_INTERVAL_MS`
+
+### `onChange`
+- **Type**: `(config: T) => void | Promise<void>`
+- **Optional**: `true`
+- **Description**: A callback function triggered when a configuration change is detected.
+
 ## Environment Variable Configuration
 
 The following environment variables can be used to configure the options:
@@ -130,6 +147,7 @@ The following environment variables can be used to configure the options:
 - `CONFIG_SERVER_URL`: Sets the `configServerUrl` option.
 - `CONFIG_OFFLINE_MODE`: Sets the `offlineMode` option.
 - `CONFIG_IGNORE_SERVER_IS_OLDER_VERSION_ERROR`: Sets the `ignoreServerIsOlderVersionError` option.
+- `CONFIG_POLL_INTERVAL_MS`: Sets the `pollIntervalMs` option.
 
 ## Configuration Merging and Validation
 
@@ -143,6 +161,7 @@ The package supports merging configurations from multiple sources (local, remote
 
 1. The remote configuration is fetched from the server specified by the `configServerUrl` option.
 2. If the `version` is set to `'latest'`, the latest version of the configuration is fetched. Otherwise, the specified version is fetched.
+3. **Continuous Polling:** If an `onChange` callback is provided, the SDK continuously polls the server using HTTP ETags (`If-None-Match`). When a `200 OK` is received (indicating a change), the configuration is automatically re-merged, validated, and the callback is triggered. `304 Not Modified` responses are silently ignored.
 
 ### Environment Variables
 
@@ -158,13 +177,15 @@ If the value of the `x-env-format` key is `json`, the environment variable value
    - Local configuration
 
 2. If a configuration option is specified in multiple sources, the value from the source with higher precedence (as listed above) is used.
+3. When a hot-reload occurs, the **Remote configuration** part is updated, and the merge is re-calculated, ensuring environment variables still win.
 
 ### Validation
 
-1. After merging, the final configuration is validated against the defined schema using ajv.
+1. After merging (and after every hot-reload), the final configuration is validated against the defined schema using ajv.
 2. The validation ensures that all required properties are present, and the types and values of properties conform to the schema.
 3. Any default value according to the schema is added to the final object.
-4. If the validation fails, an error is thrown, indicating the invalid properties and their issues.
+4. If the validation fails, an error is thrown (for initial boot) or logged (for background updates), indicating the invalid properties and their issues.
+5. **Atomic Updates:** The `ConfigInstance` only updates its internal state if the new configuration passes validation. If validation fails during a hot-reload, the previous valid state is preserved.
 
 
 # Error handling

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The package supports merging configurations from multiple sources (local, remote
 1. The remote configuration is fetched from the server specified by the `configServerUrl` option.
 2. If the `version` is set to `'latest'`, the latest version of the configuration is fetched. Otherwise, the specified version is fetched.
 3. **Continuous Polling:** If an `onChange` callback is provided, the SDK continuously polls the server using HTTP ETags (`If-None-Match`). When a `200 OK` is received (indicating a change), the configuration is automatically re-merged, validated, and the callback is triggered. `304 Not Modified` responses are silently ignored. To prevent cluster-wide traffic spikes (thundering herd), a **randomized jitter of +/- 15%** is automatically applied to each polling cycle.
+4. **Poison-Pill Quarantine:** If the user's `onChange` callback throws an error, the SDK will automatically **quarantine** that specific configuration version (ETag) in memory. This prevents the application from entering an infinite crash-and-retry loop if a bad configuration is published. Quarantined ETags will be skipped in future polling cycles until the application is restarted.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The `ConfigInstance` interface represents your way to interact with the configur
 - **Parameters**:
   - `registry` (`promClient.Registry`): The prometheus registry to use for the metrics.
 
+##### `stop(): void`
+- **Description**: Stops any background processes (like hot-reloading polling). Use this during application teardown or in tests to prevent memory leaks and hanging processes.
+
 # Configuration Options
 
 This package allows you to configure various options for loading and managing configurations. Below are the available options and their descriptions.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This package allows you to configure various options for loading and managing co
 ### `ignoreServerIsOlderVersionError`
 - **Type**: `boolean`
 - **Optional**: `true`
+- **Default**: `false`
 - **Description**: Indicates whether to ignore the error when the server version is older than the requested version.
 - **Environment Variable**: `CONFIG_IGNORE_SERVER_IS_OLDER_VERSION_ERROR`
 
@@ -128,6 +129,13 @@ This package allows you to configure various options for loading and managing co
 - **Optional**: `true`
 - **Default**: `./config`
 - **Description**: The path to the local configuration folder.
+
+### `disableHotReload`
+- **Type**: `boolean`
+- **Optional**: `true`
+- **Default**: `false`
+- **Description**: Indicates whether hot-reloading should be disabled. If true, the SDK fetches the remote configuration exactly once upon startup and never starts the background polling loop.
+- **Environment Variable**: `CONFIG_DISABLE_HOT_RELOAD`
 
 ### `pollIntervalMs`
 - **Type**: `number`
@@ -151,6 +159,7 @@ The following environment variables can be used to configure the options:
 - `CONFIG_OFFLINE_MODE`: Sets the `offlineMode` option.
 - `CONFIG_IGNORE_SERVER_IS_OLDER_VERSION_ERROR`: Sets the `ignoreServerIsOlderVersionError` option.
 - `CONFIG_POLL_INTERVAL_MS`: Sets the `pollIntervalMs` option.
+- `CONFIG_DISABLE_HOT_RELOAD`: Sets the `disableHotReload` option.
 
 ## Configuration Merging and Validation
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
   debug('config called with options: %j', { ...options, schema: options.schema.$id });
   const { schema: baseSchema, metricsRegistry, onChange, ...unvalidatedOptions } = options;
   const initOptions = initializeOptions(unvalidatedOptions);
-  const { configName, offlineMode, version, ignoreServerIsOlderVersionError } = initOptions;
+  const { configName, offlineMode, version, ignoreServerIsOlderVersionError, disableHotReload } = initOptions;
 
   // Load Local and Env Configs First (Independent of remote state)
   const dereferencedSchema = await loadSchema(baseSchema);
@@ -77,7 +77,12 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
   let validatedConfig: ReturnType<typeof mergeAndValidate>;
 
   // Handle Remote Config and Polling
-  if (offlineMode !== true) {
+  if (!offlineMode) {
+    if (!disableHotReload && onChange === undefined) {
+      debug('Hot reload is enabled but no onChange callback was provided');
+      throw createConfigError('onChangeCallbackMissingError', `Hot reload is enabled but no 'onChange' callback was provided`, {});
+    }
+
     debug('handling fetching remote data');
     // check if the server is using an older version of the schemas package
     const capabilitiesResponse = await getServerCapabilities();
@@ -90,7 +95,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
         satisfies: semverSatisfies,
       });
     }
-    if (ignoreServerIsOlderVersionError !== true && gt(LOCAL_SCHEMAS_PACKAGE_VERSION, capabilitiesResponse.schemasPackageVersion)) {
+    if (!ignoreServerIsOlderVersionError && gt(LOCAL_SCHEMAS_PACKAGE_VERSION, capabilitiesResponse.schemasPackageVersion)) {
       debug(
         'server is using an older version of the schemas package. local: %s, remote: %s',
         LOCAL_SCHEMAS_PACKAGE_VERSION,
@@ -129,7 +134,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
     validatedConfig = mergeAndValidate(remoteConfig);
 
     // Setup polling
-    if (onChange) {
+    if (!disableHotReload) {
       changeDetector = new ChangeDetector(
         baseSchema.$id,
         initOptions,
@@ -137,7 +142,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
           const newlyValidatedConfig = mergeAndValidate(newRemoteConfig);
           validatedConfig = newlyValidatedConfig;
           remoteConfig = newRemoteConfig;
-          await onChange(newlyValidatedConfig);
+          await onChange!(newlyValidatedConfig);
         },
         currentEtag
       );

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
     return validatedConfig;
   }
 
+  let changeDetector: ChangeDetector | undefined = undefined;
   let remoteConfig: object | T = {};
   let serverConfigResponse: Config | undefined = undefined;
   let validatedConfig: ReturnType<typeof mergeAndValidate>;
@@ -129,7 +130,7 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
 
     // Setup polling
     if (onChange) {
-      const changeDetector = new ChangeDetector(
+      changeDetector = new ChangeDetector(
         baseSchema.$id,
         initOptions,
         async (newRemoteConfig: object) => {
@@ -175,5 +176,12 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
     initializeMetricsInternal(registry, baseSchema.$id, serverConfigResponse?.version);
   }
 
-  return { get, getAll, getConfigParts, getResolvedOptions, initializeMetrics };
+  function stop(): void {
+    debug('stop called');
+    if (changeDetector) {
+      changeDetector.stop();
+    }
+  }
+
+  return { get, getAll, getConfigParts, getResolvedOptions, initializeMetrics, stop };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ import { LOCAL_SCHEMAS_PACKAGE_VERSION } from './constants';
 import { createConfigError } from './errors';
 import { initializeMetrics as initializeMetricsInternal } from './metrics';
 import { deepFreeze } from './utils/helpers';
+import { ChangeDetector } from './rollout/ChangeDetector';
 
 const debug = createDebug('config');
 
@@ -25,22 +26,56 @@ const semverSatisfies = '2.x';
 /**
  * Retrieves the configuration based on the provided options.
  *
+ * If `onChange` is provided in the options and `offlineMode` is not enabled, the SDK starts a background
+ * polling mechanism. The returned `ConfigInstance` serves as a live state machine; its `get` and `getAll`
+ * methods will return the most recent configuration retrieved from the server during hot-reloads.
+ *
  * @template T - The type of the configuration schema.
  * @param {ConfigOptions<T>} options - The options for retrieving the configuration.
- * @returns {Promise<ConfigInstance<T>>} - A promise that resolves to the configuration object.
+ * @returns {Promise<ConfigInstance<T[typeof typeSymbol]>>} - A promise that resolves to the configuration object.
  */
 export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
   options: ConfigOptions<T>
 ): Promise<ConfigInstance<T[typeof typeSymbol]>> {
   // handle package options
   debug('config called with options: %j', { ...options, schema: options.schema.$id });
-  const { schema: baseSchema, metricsRegistry, ...unvalidatedOptions } = options;
-  const { configName, offlineMode, version, ignoreServerIsOlderVersionError } = initializeOptions(unvalidatedOptions);
+  const { schema: baseSchema, metricsRegistry, onChange, ...unvalidatedOptions } = options;
+  const initOptions = initializeOptions(unvalidatedOptions);
+  const { configName, offlineMode, version, ignoreServerIsOlderVersionError } = initOptions;
+
+  // Load Local and Env Configs First (Independent of remote state)
+  const dereferencedSchema = await loadSchema(baseSchema);
+  const localConfig = configPkg.util.loadFileConfigs(options.localConfigPath) as { [key: string]: unknown };
+  debug('local config: %j', localConfig);
+  const envConfig = getEnvValues(dereferencedSchema);
+  debug('env config: %j', envConfig);
+
+  /**
+   * Function to merge local, remote, and environment configs and validate the merged result against the schema.
+   * The precedence order for merging is: local < remote < environment.
+   */
+  function mergeAndValidate(remoteConfig: object | T): unknown {
+    const mergedConfig = deepmerge.all([localConfig, remoteConfig, envConfig], { arrayMerge });
+    debug('merged config: %j', mergedConfig);
+
+    // validate the merged config
+    const [errors, validatedConfig] = validate(ajvConfigValidator, dereferencedSchema, mergedConfig);
+    if (errors) {
+      debug('config validation error: %j', errors);
+      throw createConfigError('configValidationError', 'Config validation error', errors);
+    }
+
+    debug('freezing validated config');
+    // freeze the merged config so it can't be modified by the package user and to ensure that the config instance always returns the same reference for the same config, which is important for change detection and to prevent unnecessary re-renders in case the config is used in a React application and the user is using the getConfigParts method to get the config and pass it to their components
+    deepFreeze(validatedConfig);
+    return validatedConfig;
+  }
 
   let remoteConfig: object | T = {};
-
   let serverConfigResponse: Config | undefined = undefined;
-  // handle remote config
+  let validatedConfig: ReturnType<typeof mergeAndValidate>;
+
+  // Handle Remote Config and Polling
   if (offlineMode !== true) {
     debug('handling fetching remote data');
     // check if the server is using an older version of the schemas package
@@ -70,8 +105,10 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
       );
     }
 
-    // get the remote config
-    serverConfigResponse = await getRemoteConfig(configName, options.schema.$id, version);
+    // get the initial remote config
+    const remoteResponse = await getRemoteConfig(configName, options.schema.$id, version);
+    serverConfigResponse = remoteResponse.config!;
+    const currentEtag = remoteResponse.etag;
 
     if (serverConfigResponse.schemaId !== baseSchema.$id) {
       debug('schema version mismatch. local: %s, remote: %s', baseSchema.$id, serverConfigResponse.schemaId);
@@ -86,31 +123,29 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
     }
 
     remoteConfig = serverConfigResponse.config;
+    debug('remote config: %j', remoteConfig);
+
+    validatedConfig = mergeAndValidate(remoteConfig);
+
+    // Setup polling
+    if (onChange) {
+      const changeDetector = new ChangeDetector(
+        baseSchema.$id,
+        initOptions,
+        async (newRemoteConfig: object) => {
+          const newlyValidatedConfig = mergeAndValidate(newRemoteConfig);
+          validatedConfig = newlyValidatedConfig;
+          remoteConfig = newRemoteConfig;
+          await onChange(newlyValidatedConfig);
+        },
+        currentEtag
+      );
+      changeDetector.start();
+    }
+  } else {
+    // If offline, bypass remote and just merge local/env
+    validatedConfig = mergeAndValidate({});
   }
-  debug('remote config: %j', remoteConfig);
-
-  const dereferencedSchema = await loadSchema(baseSchema);
-
-  const localConfig = configPkg.util.loadFileConfigs(options.localConfigPath) as { [key: string]: unknown };
-  debug('local config: %j', localConfig);
-
-  const envConfig = getEnvValues(dereferencedSchema);
-  debug('env config: %j', envConfig);
-
-  // merge all the configs into one object with the following priority: localConfig < remoteConfig < envConfig
-  const mergedConfig = deepmerge.all([localConfig, remoteConfig, envConfig], { arrayMerge });
-  debug('merged config: %j', mergedConfig);
-
-  // validate the merged config
-  const [errors, validatedConfig] = validate(ajvConfigValidator, dereferencedSchema, mergedConfig);
-  if (errors) {
-    debug('config validation error: %j', errors);
-    throw createConfigError('configValidationError', 'Config validation error', errors);
-  }
-
-  debug('freezing validated config');
-  // freeze the merged config so it can't be modified by the package user
-  deepFreeze(validatedConfig);
 
   function get<TPath extends string>(path: TPath): GetFieldType<T[typeof typeSymbol], TPath> {
     debug('get called with path: %s', path);

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,9 +140,9 @@ export async function config<T extends { [typeSymbol]: unknown; $id: string }>(
         initOptions,
         async (newRemoteConfig: object) => {
           const newlyValidatedConfig = mergeAndValidate(newRemoteConfig);
+          await onChange!(newlyValidatedConfig);
           validatedConfig = newlyValidatedConfig;
           remoteConfig = newRemoteConfig;
-          await onChange!(newlyValidatedConfig);
         },
         currentEtag
       );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,5 @@ export const SCHEMA_DOMAIN = 'https://mapcolonies.com/';
 
 export const SCHEMAS_PACKAGE_RESOLVED_PATH = require.resolve('@map-colonies/schemas');
 export const SCHEMA_BASE_PATH = SCHEMAS_PACKAGE_RESOLVED_PATH.substring(0, SCHEMAS_PACKAGE_RESOLVED_PATH.lastIndexOf(path.sep));
+
+export const JITTER_PERCENTAGE = 0.15;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,6 +11,7 @@ const configErrors = {
   schemaVersionMismatchError: { code: 7, payload: {} as { remoteSchemaVersion: string; localSchemaVersion: string } },
   promClientNotInstalledError: { code: 8, payload: {} as { message: string } },
   serverVersionMismatchError: { code: 9, payload: {} as { remoteServerVersion: string; localServerVersion: string; satisfies: string } },
+  onChangeCallbackMissingError: { code: 10, payload: {} },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as const satisfies Record<string, { code: number; payload: any }>;
 

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -15,10 +15,10 @@ async function createHttpErrorPayload(res: Dispatcher.ResponseData): Promise<Con
   };
 }
 
-async function requestWrapper(url: string, query?: Record<string, unknown>): Promise<Dispatcher.ResponseData> {
+async function requestWrapper(url: string, options: Parameters<typeof request<null>>[1] = undefined): Promise<Dispatcher.ResponseData> {
   debug('Making request to %s', url);
   try {
-    const res = await request(url, { query });
+    const res = await request(url, options);
     if (res.statusCode > statusCodes.NOT_FOUND) {
       debug('Failed to fetch config. Status code: %d', res.statusCode);
       throw createConfigError('httpResponseError', 'Failed to fetch', await createHttpErrorPayload(res));
@@ -33,12 +33,25 @@ async function requestWrapper(url: string, query?: Record<string, unknown>): Pro
   }
 }
 
-export async function getRemoteConfig(configName: string, schemaId: string, version: number | 'latest'): Promise<Config> {
+export async function getRemoteConfig(
+  configName: string,
+  schemaId: string,
+  version: number | 'latest',
+  etag?: string
+): Promise<{ config: Config | null; etag: string }> {
   debug('Fetching remote config %s@%s', configName, version);
   const { configServerUrl } = getOptions();
   const url = `${configServerUrl}/config/${configName}/${version}`;
 
-  const res = await requestWrapper(url, { shouldDereference: true, schemaId });
+  const headers = etag !== undefined ? { 'If-None-Match': etag } : undefined;
+  const queryParams = { schemaId, shouldDereference: 'true' };
+
+  const res = await requestWrapper(url, { query: queryParams, headers });
+
+  if (res.statusCode === statusCodes.NOT_MODIFIED) {
+    debug('Config was not modified');
+    return { config: null, etag: etag! };
+  }
 
   if (res.statusCode === statusCodes.BAD_REQUEST) {
     debug('Invalid request to getConfig');
@@ -51,7 +64,7 @@ export async function getRemoteConfig(configName: string, schemaId: string, vers
   }
   debug('Config fetched successfully');
 
-  return (await res.body.json()) as Config;
+  return { config: (await res.body.json()) as Config, etag: res.headers.etag as string };
 }
 
 export async function getServerCapabilities(): Promise<ServerCapabilities> {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -46,7 +46,7 @@ export function initializeMetrics(registry: Registry, schemaId: string, actualVe
       name: configName,
       request_version: version,
       actual_version: actualVersion,
-      offline_mode: String(offlineMode ?? false),
+      offline_mode: String(offlineMode),
       schemas_package_version: LOCAL_SCHEMAS_PACKAGE_VERSION,
       package_version: PACKAGE_VERSION,
       schema_id: schemaId,

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ const defaultOptions: BaseOptions = {
   configName: PACKAGE_NAME,
   configServerUrl: 'http://localhost:8080',
   version: 'latest',
+  pollIntervalMs: 30000,
 };
 
 const envOptions: Partial<Record<keyof BaseOptions, string>> = {
@@ -19,6 +20,7 @@ const envOptions: Partial<Record<keyof BaseOptions, string>> = {
   version: process.env.CONFIG_VERSION,
   offlineMode: process.env.CONFIG_OFFLINE_MODE,
   ignoreServerIsOlderVersionError: process.env.CONFIG_IGNORE_SERVER_IS_OLDER_VERSION_ERROR,
+  pollIntervalMs: process.env.CONFIG_POLL_INTERVAL_MS,
 };
 
 // in order to merge correctly the keys should not exist, undefined is not enough

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,6 +12,10 @@ const defaultOptions: BaseOptions = {
   configServerUrl: 'http://localhost:8080',
   version: 'latest',
   pollIntervalMs: 30000,
+  offlineMode: false,
+  ignoreServerIsOlderVersionError: false,
+  localConfigPath: './config',
+  disableHotReload: false,
 };
 
 const envOptions: Partial<Record<keyof BaseOptions, string>> = {
@@ -21,6 +25,7 @@ const envOptions: Partial<Record<keyof BaseOptions, string>> = {
   offlineMode: process.env.CONFIG_OFFLINE_MODE,
   ignoreServerIsOlderVersionError: process.env.CONFIG_IGNORE_SERVER_IS_OLDER_VERSION_ERROR,
   pollIntervalMs: process.env.CONFIG_POLL_INTERVAL_MS,
+  disableHotReload: process.env.CONFIG_DISABLE_HOT_RELOAD,
 };
 
 // in order to merge correctly the keys should not exist, undefined is not enough

--- a/src/rollout/ChangeDetector.ts
+++ b/src/rollout/ChangeDetector.ts
@@ -38,7 +38,7 @@ export class ChangeDetector {
     if (this.timer) {
       clearTimeout(this.timer);
     }
-    const baseInterval = this.options.pollIntervalMs!;
+    const baseInterval = this.options.pollIntervalMs;
     const jitter = baseInterval * JITTER_PERCENTAGE;
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     const randomJitter = (Math.random() * 2 - 1) * jitter;

--- a/src/rollout/ChangeDetector.ts
+++ b/src/rollout/ChangeDetector.ts
@@ -12,6 +12,7 @@ const debug = createDebug('changeDetector');
 export class ChangeDetector {
   private currentEtag: string;
   private timer?: NodeJS.Timeout;
+  private readonly etagBlackList: Set<string> = new Set();
 
   public constructor(
     private readonly schemaId: string,
@@ -68,8 +69,21 @@ export class ChangeDetector {
       return;
     }
 
+    const newEtag = response.etag;
+    if (this.etagBlackList.has(newEtag)) {
+      debug('Detected quarantined etag %s. Skipping update.', newEtag);
+      this.currentEtag = newEtag;
+      return;
+    }
+
     debug('Config change detected');
-    this.currentEtag = response.etag!;
-    await this.onConfigUpdate(response.config.config);
+    try {
+      await this.onConfigUpdate(response.config.config);
+      this.currentEtag = newEtag;
+    } catch (err) {
+      debug('Error applying configuration for etag %s. Adding to poison pills. Error: %s', newEtag, (err as Error).message);
+      this.etagBlackList.add(newEtag);
+      this.currentEtag = newEtag;
+    }
   }
 }

--- a/src/rollout/ChangeDetector.ts
+++ b/src/rollout/ChangeDetector.ts
@@ -1,3 +1,4 @@
+import { JITTER_PERCENTAGE } from '../constants';
 import { getRemoteConfig } from '../httpClient';
 import { BaseOptions } from '../types';
 import { createDebug } from '../utils/debug';
@@ -22,21 +23,39 @@ export class ChangeDetector {
   }
 
   public start(): void {
-    const interval = this.options.pollIntervalMs;
-    debug('Starting change detector with interval %d ms', interval);
-
-    this.timer = setInterval(() => {
-      this.poll().catch((err) => {
-        debug('Error during polling: %s', (err as Error).message);
-      });
-    }, interval);
+    debug('Starting change detector');
+    this.scheduleNextPoll();
   }
 
   public stop(): void {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = undefined;
     }
+  }
+
+  private scheduleNextPoll(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    const baseInterval = this.options.pollIntervalMs!;
+    const jitter = baseInterval * JITTER_PERCENTAGE;
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    const randomJitter = (Math.random() * 2 - 1) * jitter;
+    const nextInterval = baseInterval + randomJitter;
+
+    debug('Scheduling next poll in %d ms', nextInterval);
+    this.timer = setTimeout(() => {
+      this.poll()
+        .catch((err) => {
+          debug('Error during polling: %s', (err as Error).message);
+        })
+        .finally(() => {
+          if (this.timer !== undefined) {
+            this.scheduleNextPoll();
+          }
+        });
+    }, nextInterval);
   }
 
   private async poll(): Promise<void> {

--- a/src/rollout/ChangeDetector.ts
+++ b/src/rollout/ChangeDetector.ts
@@ -1,0 +1,56 @@
+import { getRemoteConfig } from '../httpClient';
+import { BaseOptions } from '../types';
+import { createDebug } from '../utils/debug';
+
+const debug = createDebug('changeDetector');
+
+/**
+ * Class responsible for detecting changes in the remote configuration by periodically polling the server and comparing ETags.
+ * If a change is detected, it invokes the provided callback with the new configuration.
+ */
+export class ChangeDetector {
+  private currentEtag: string;
+  private timer?: NodeJS.Timeout;
+
+  public constructor(
+    private readonly schemaId: string,
+    private readonly options: BaseOptions,
+    private readonly onConfigUpdate: (newRemoteConfig: object) => void | Promise<void>,
+    initialEtag: string
+  ) {
+    this.currentEtag = initialEtag;
+  }
+
+  public start(): void {
+    const interval = this.options.pollIntervalMs;
+    debug('Starting change detector with interval %d ms', interval);
+
+    this.timer = setInterval(() => {
+      this.poll().catch((err) => {
+        debug('Error during polling: %s', (err as Error).message);
+      });
+    }, interval);
+  }
+
+  public stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private async poll(): Promise<void> {
+    debug('Polling config %s@%s with etag %s', this.options.configName, this.options.version, this.currentEtag);
+
+    const response = await getRemoteConfig(this.options.configName, this.schemaId, this.options.version, this.currentEtag);
+
+    if (response.config === null) {
+      debug('No config changes detected');
+      return;
+    }
+
+    debug('Config change detected');
+    this.currentEtag = response.etag!;
+    await this.onConfigUpdate(response.config.config);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,4 +159,9 @@ export interface ConfigInstance<T> {
    * @param registry - The registry for the metrics.
    */
   initializeMetrics: (registry: Registry) => void;
+
+  /**
+   * Stops any background processes (like hot-reloading polling).
+   */
+  stop: () => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,11 @@ export interface BaseOptions {
    * @default './config'
    */
   localConfigPath?: string;
+  /**
+   * The polling interval in milliseconds.
+   * @default 30000
+   */
+  pollIntervalMs?: number;
 }
 
 /**
@@ -82,6 +87,10 @@ export type ConfigOptions<T extends SchemaWithType> = Prettify<
      * Depends on the prom-client package being installed.
      */
     metricsRegistry?: Registry;
+    /**
+     * The callback function that is triggered when the configuration changes.
+     */
+    onChange?: (config: unknown) => void | Promise<void>;
   }
 >;
 
@@ -101,16 +110,20 @@ export const optionsSchema: JSONSchemaType<BaseOptions> = {
     offlineMode: { type: 'boolean', nullable: true },
     ignoreServerIsOlderVersionError: { type: 'boolean', nullable: true },
     localConfigPath: { type: 'string', default: './config', nullable: true },
+    pollIntervalMs: { type: 'integer', default: 30000, nullable: true },
   },
 };
 
 /**
- * Represents the schema of the configuration object.
+ * Represents a live configuration instance.
+ * When hot-reloading is enabled, this instance acts as a state machine that updates its internal
+ * configuration state dynamically.
  * @template T - The type of the configuration schema.
  */
 export interface ConfigInstance<T> {
   /**
    * Retrieves the value at the specified path from the configuration object.
+   * If hot-reloading is active, this returns the value from the most recent configuration update.
    * @template TPath - The type of the path.
    * @param path - The path to the desired value.
    * @returns The value at the specified path.
@@ -119,12 +132,14 @@ export interface ConfigInstance<T> {
 
   /**
    * Retrieves the entire configuration object.
+   * If hot-reloading is active, this returns the most recent configuration state.
    * @returns The entire configuration object.
    */
   getAll: () => T;
 
   /**
    * Retrieves different parts of the configuration object before being merged and validated.
+   * If hot-reloading is active, 'config' reflects the latest remote payload.
    * @returns An object containing the localConfig, config, and envConfig parts of the configuration.
    */
   getConfigParts: () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,21 +56,27 @@ export interface BaseOptions {
   /**
    * Indicates whether the configuration should be loaded in offline mode.
    */
-  offlineMode?: boolean;
+  offlineMode: boolean;
   /**
    * Indicates whether to ignore the error when the server version is older than the requested version.
    */
-  ignoreServerIsOlderVersionError?: boolean;
+  ignoreServerIsOlderVersionError: boolean;
   /**
    * The path to the local configuration folder.
    * @default './config'
    */
-  localConfigPath?: string;
+  localConfigPath: string;
   /**
    * The polling interval in milliseconds.
    * @default 30000
    */
-  pollIntervalMs?: number;
+  pollIntervalMs: number;
+  /**
+   * Indicates whether hot-reloading should be disabled.
+   * If true, the SDK fetches the remote configuration exactly once upon startup.
+   * @default false
+   */
+  disableHotReload: boolean;
 }
 
 /**
@@ -107,10 +113,11 @@ export const optionsSchema: JSONSchemaType<BaseOptions> = {
       ],
     },
     configServerUrl: { type: 'string' },
-    offlineMode: { type: 'boolean', nullable: true },
-    ignoreServerIsOlderVersionError: { type: 'boolean', nullable: true },
-    localConfigPath: { type: 'string', default: './config', nullable: true },
-    pollIntervalMs: { type: 'integer', default: 30000, nullable: true },
+    offlineMode: { type: 'boolean' },
+    ignoreServerIsOlderVersionError: { type: 'boolean' },
+    localConfigPath: { type: 'string', default: './config' },
+    pollIntervalMs: { type: 'integer', default: 30000 },
+    disableHotReload: { type: 'boolean', default: false },
   },
 };
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -40,6 +40,7 @@ describe('config', () => {
         schema: commonDbPartialV1,
         configServerUrl: URL,
         localConfigPath: './tests/config',
+        onChange: async () => {},
       });
 
       const conf = configInstance.getAll();
@@ -125,6 +126,7 @@ describe('config', () => {
         schema: commonDbPartialV1,
         configServerUrl: URL,
         localConfigPath: './tests/config',
+        onChange: async () => {},
       });
 
       const conf = configInstance.getAll();
@@ -185,6 +187,7 @@ describe('config', () => {
         schema: commonDbPartialV1,
         configServerUrl: URL,
         localConfigPath: './tests/config',
+        onChange: async () => {},
       });
 
       const parts = configInstance.getConfigParts();
@@ -222,6 +225,8 @@ describe('config', () => {
         localConfigPath: './tests/config',
         offlineMode: true,
         pollIntervalMs: 3000,
+        disableHotReload: false,
+        ignoreServerIsOlderVersionError: false,
       });
     });
 
@@ -249,6 +254,7 @@ describe('config', () => {
         schema: commonS3PartialV1,
         configServerUrl: URL,
         localConfigPath: './tests/config',
+        onChange: async () => {},
       });
 
       await expect(promise).rejects.toThrow('The schema version of the remote config does not match the schema version of the local config');
@@ -280,6 +286,7 @@ describe('config', () => {
         schema: commonDbPartialV1,
         configServerUrl: URL,
         localConfigPath: './tests/config',
+        onChange: async () => {},
       });
 
       await expect(promise).rejects.toThrow('Config validation error');
@@ -378,6 +385,7 @@ describe('config', () => {
         schema: commonDbPartialV1,
         configServerUrl: URL,
         localConfigPath: './tests/config',
+        onChange: async () => {},
       });
 
       await expect(promise).rejects.toThrow('The server version does not satisfy the required version.');

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -210,6 +210,7 @@ describe('config', () => {
         configServerUrl: URL,
         localConfigPath: './tests/config',
         offlineMode: true,
+        pollIntervalMs: 3000,
       });
 
       const options = configInstance.getResolvedOptions();
@@ -220,6 +221,7 @@ describe('config', () => {
         configServerUrl: URL,
         localConfigPath: './tests/config',
         offlineMode: true,
+        pollIntervalMs: 3000,
       });
     });
 

--- a/tests/httpClient.spec.ts
+++ b/tests/httpClient.spec.ts
@@ -62,7 +62,7 @@ describe('httpClient', () => {
       client.intercept({ path: '/config/name/1?shouldDereference=true&schemaId=schema', method: 'GET' }).reply(StatusCodes.OK, config);
 
       const result = await getRemoteConfig('name', 'schema', 1);
-      expect(result).toEqual(config);
+      expect(result).toEqual({ config: config, etag: undefined });
     });
 
     it('should throw an error if the response is bad request', async () => {

--- a/tests/options.spec.ts
+++ b/tests/options.spec.ts
@@ -73,6 +73,7 @@ describe('options', () => {
       ['version', 'CONFIG_VERSION', 'latest', 'latest'],
       ['offlineMode', 'CONFIG_OFFLINE_MODE', 'true', true],
       ['ignoreServerIsOlderVersionError', 'CONFIG_IGNORE_SERVER_IS_OLDER_VERSION_ERROR', 'true', true],
+      ['pollIntervalMs', 'CONFIG_POLL_INTERVAL_MS', '10000', 10000],
     ])('should initialize options and override with provided environment variable %s', async (key, envKey, envValue, expected) => {
       process.env[envKey] = envValue;
 

--- a/tests/rollout.spec.ts
+++ b/tests/rollout.spec.ts
@@ -266,4 +266,75 @@ describe('Continuous Polling (ChangeDetector)', () => {
     // Assert
     expect(onChangeMock).not.toHaveBeenCalled();
   });
+
+  it('should quarantine a failing ETag and not retry it', async () => {
+    // Arrange
+    const initialConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: { host: 'initial-host' },
+      createdAt: 0,
+    };
+    const badConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: { host: 'bad-host' },
+      createdAt: 1,
+    };
+
+    client
+      .intercept({ path: '/capabilities', method: 'GET' })
+      .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+    client
+      .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
+      .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'initial-etag' } });
+
+    const onChangeMock = vi.fn().mockImplementation((conf) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (conf.host === 'bad-host') {
+        throw new Error('Boom!');
+      }
+    });
+
+    const configInstance = await config({
+      configName: 'name',
+      version: 1,
+      schema: commonDbPartialV1,
+      configServerUrl: URL,
+      localConfigPath: './tests/config',
+      pollIntervalMs: DEFAULT_POLL_INTERVAL,
+      onChange: onChangeMock,
+    });
+
+    // Act (Trigger poll with bad config)
+    client
+      .intercept({
+        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
+        method: 'GET',
+        headers: { 'if-none-match': 'initial-etag' },
+      })
+      .reply(StatusCodes.OK, badConfigData, { headers: { etag: 'bad-etag' } });
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL * (1 + JITTER_PERCENTAGE));
+
+    // Assert (Fails once and is quarantined)
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+    expect(configInstance.get('host')).toBe('initial-host'); // Should not have updated
+
+    // Act (Poll again with SAME bad config)
+    client
+      .intercept({
+        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
+        method: 'GET',
+        headers: { 'if-none-match': 'bad-etag' },
+      })
+      .reply(StatusCodes.OK, badConfigData, { headers: { etag: 'bad-etag' } });
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL * (1 + JITTER_PERCENTAGE));
+
+    // Assert (Should NOT have called onChangeMock again)
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/rollout.spec.ts
+++ b/tests/rollout.spec.ts
@@ -228,4 +228,42 @@ describe('Continuous Polling (ChangeDetector)', () => {
 
     setTimeoutSpy.mockRestore();
   });
+
+  it('should not start polling if disableHotReload is true', async () => {
+    // Arrange
+    const initialConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: { host: 'initial-host' },
+      createdAt: 0,
+    };
+
+    client
+      .intercept({ path: '/capabilities', method: 'GET' })
+      .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+    client
+      .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
+      .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
+
+    const onChangeMock = vi.fn();
+
+    // Act
+    await config({
+      configName: 'name',
+      version: 1,
+      schema: commonDbPartialV1,
+      configServerUrl: URL,
+      localConfigPath: './tests/config',
+      pollIntervalMs: DEFAULT_POLL_INTERVAL,
+      onChange: onChangeMock,
+      disableHotReload: true,
+    });
+
+    // Advance time beyond the polling interval
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL * (1 + JITTER_PERCENTAGE) + 1);
+
+    // Assert
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/rollout.spec.ts
+++ b/tests/rollout.spec.ts
@@ -3,6 +3,7 @@ import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
 import { commonDbPartialV1 } from '@map-colonies/schemas';
 import { StatusCodes } from 'http-status-codes';
 import { config } from '../src/config';
+import { JITTER_PERCENTAGE } from '../src/constants';
 
 const URL = 'http://localhost:8080';
 const DEFAULT_POLL_INTERVAL = 10000;
@@ -74,7 +75,7 @@ describe('Continuous Polling (ChangeDetector)', () => {
       .reply(StatusCodes.OK, newConfigData, { headers: { etag: 'etag-2' } });
 
     // Act (Wait for Poll)
-    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL);
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL * (1 + JITTER_PERCENTAGE));
 
     // Assert (Updated State)
     expect(onChangeMock).toHaveBeenCalledTimes(1);
@@ -121,7 +122,7 @@ describe('Continuous Polling (ChangeDetector)', () => {
       .reply(StatusCodes.NOT_MODIFIED);
 
     // Act (Wait for Poll)
-    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL);
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL * (1 + JITTER_PERCENTAGE));
 
     // Assert
     expect(onChangeMock).not.toHaveBeenCalled();
@@ -165,5 +166,66 @@ describe('Continuous Polling (ChangeDetector)', () => {
 
     // Assert
     expect(onChangeMock).not.toHaveBeenCalled();
+  });
+
+  it('should apply randomized jitter within boundaries over 10 cycles', async () => {
+    // Arrange
+    const initialConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: { host: 'initial-host' },
+      createdAt: 0,
+    };
+
+    client
+      .intercept({ path: '/capabilities', method: 'GET' })
+      .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+    client
+      .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
+      .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
+
+    // Setup 10 mock 304 responses
+    client
+      .intercept({
+        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
+        method: 'GET',
+      })
+      .reply(StatusCodes.NOT_MODIFIED)
+      .times(10);
+
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    // Act
+    await config({
+      configName: 'name',
+      version: 1,
+      schema: commonDbPartialV1,
+      configServerUrl: URL,
+      localConfigPath: './tests/config',
+      pollIntervalMs: DEFAULT_POLL_INTERVAL,
+      onChange: vi.fn(),
+    });
+
+    const maxJitter = DEFAULT_POLL_INTERVAL * JITTER_PERCENTAGE;
+    const minWait = DEFAULT_POLL_INTERVAL - maxJitter;
+    const maxWait = DEFAULT_POLL_INTERVAL + maxJitter;
+
+    // Run 10 cycles
+    for (let i = 0; i < 10; i++) {
+      // Advance timers by maxWait to definitely trigger the next poll
+      await vi.advanceTimersByTimeAsync(maxWait + 1);
+    }
+
+    // Assert
+    const pollTimeouts = setTimeoutSpy.mock.calls.map((call) => call[1] as number).filter((time) => time >= minWait && time <= maxWait);
+
+    expect(pollTimeouts.length).toBeGreaterThanOrEqual(10);
+    pollTimeouts.forEach((time) => {
+      expect(time).toBeGreaterThanOrEqual(minWait);
+      expect(time).toBeLessThanOrEqual(maxWait);
+    });
+
+    setTimeoutSpy.mockRestore();
   });
 });

--- a/tests/rollout.spec.ts
+++ b/tests/rollout.spec.ts
@@ -5,6 +5,7 @@ import { StatusCodes } from 'http-status-codes';
 import { config } from '../src/config';
 
 const URL = 'http://localhost:8080';
+const DEFAULT_POLL_INTERVAL = 10000;
 
 describe('Continuous Polling (ChangeDetector)', () => {
   let client: Interceptable;
@@ -23,52 +24,47 @@ describe('Continuous Polling (ChangeDetector)', () => {
   });
 
   it('should trigger onChange when polling returns a new config (200 OK)', async () => {
+    // Arrange
     const initialConfigData = {
       configName: 'name',
       schemaId: commonDbPartialV1.$id,
       version: 1,
-      config: {
-        host: 'initial-host',
-      },
+      config: { host: 'initial-host' },
       createdAt: 0,
     };
-
     const newConfigData = {
       configName: 'name',
       schemaId: commonDbPartialV1.$id,
       version: 1,
-      config: {
-        host: 'updated-host',
-      },
+      config: { host: 'updated-host' },
       createdAt: 1,
     };
 
-    // Initial capabilities fetch
     client
       .intercept({ path: '/capabilities', method: 'GET' })
       .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
-
-    // Initial config fetch
     client
       .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
       .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
 
     const onChangeMock = vi.fn();
 
+    // Act
     const configInstance = await config({
       configName: 'name',
       version: 1,
       schema: commonDbPartialV1,
       configServerUrl: URL,
       localConfigPath: './tests/config',
-      pollIntervalMs: 10000,
+      pollIntervalMs: DEFAULT_POLL_INTERVAL,
       onChange: onChangeMock,
     });
 
+    // Assert (Initial State)
     expect(configInstance.get('host')).toBe('initial-host');
     expect(onChangeMock).not.toHaveBeenCalled();
 
-    // Setup next poll response
+    // Arrange (Next Poll)
     client
       .intercept({
         path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
@@ -77,34 +73,74 @@ describe('Continuous Polling (ChangeDetector)', () => {
       })
       .reply(StatusCodes.OK, newConfigData, { headers: { etag: 'etag-2' } });
 
-    // Advance time to trigger poll
-    await vi.advanceTimersByTimeAsync(10000);
+    // Act (Wait for Poll)
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL);
 
+    // Assert (Updated State)
     expect(onChangeMock).toHaveBeenCalledTimes(1);
-    expect(onChangeMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        host: 'updated-host',
-      })
-    );
+    expect(onChangeMock).toHaveBeenCalledWith(expect.objectContaining({ host: 'updated-host' }));
   });
 
   it('should not trigger onChange when polling returns 304 Not Modified', async () => {
+    // Arrange
     const initialConfigData = {
       configName: 'name',
       schemaId: commonDbPartialV1.$id,
       version: 1,
-      config: {
-        host: 'initial-host',
-      },
+      config: { host: 'initial-host' },
       createdAt: 0,
     };
 
-    // Initial capabilities fetch
     client
       .intercept({ path: '/capabilities', method: 'GET' })
       .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+    client
+      .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
+      .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
 
-    // Initial config fetch
+    const onChangeMock = vi.fn();
+
+    // Act
+    const configInstance = await config({
+      configName: 'name',
+      version: 1,
+      schema: commonDbPartialV1,
+      configServerUrl: URL,
+      localConfigPath: './tests/config',
+      pollIntervalMs: DEFAULT_POLL_INTERVAL,
+      onChange: onChangeMock,
+    });
+
+    // Arrange (Setup 304 response)
+    client
+      .intercept({
+        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
+        method: 'GET',
+        headers: { 'if-none-match': 'etag-1' },
+      })
+      .reply(StatusCodes.NOT_MODIFIED);
+
+    // Act (Wait for Poll)
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL);
+
+    // Assert
+    expect(onChangeMock).not.toHaveBeenCalled();
+    expect(configInstance.get('host')).toBe('initial-host');
+  });
+
+  it('should stop polling when stop is called', async () => {
+    // Arrange
+    const initialConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: { host: 'initial-host' },
+      createdAt: 0,
+    };
+
+    client
+      .intercept({ path: '/capabilities', method: 'GET' })
+      .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
     client
       .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
       .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
@@ -117,23 +153,17 @@ describe('Continuous Polling (ChangeDetector)', () => {
       schema: commonDbPartialV1,
       configServerUrl: URL,
       localConfigPath: './tests/config',
-      pollIntervalMs: 10000,
+      pollIntervalMs: DEFAULT_POLL_INTERVAL,
       onChange: onChangeMock,
     });
 
-    // Setup next poll response (304)
-    client
-      .intercept({
-        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
-        method: 'GET',
-        headers: { 'if-none-match': 'etag-1' },
-      })
-      .reply(StatusCodes.NOT_MODIFIED);
+    // Act
+    configInstance.stop();
 
-    // Advance time to trigger poll
-    await vi.advanceTimersByTimeAsync(10000);
+    // Advance time beyond the polling interval
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL * 2);
 
+    // Assert
     expect(onChangeMock).not.toHaveBeenCalled();
-    expect(configInstance.get('host')).toBe('initial-host');
   });
 });

--- a/tests/rollout.spec.ts
+++ b/tests/rollout.spec.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { commonDbPartialV1 } from '@map-colonies/schemas';
+import { StatusCodes } from 'http-status-codes';
+import { config } from '../src/config';
+
+const URL = 'http://localhost:8080';
+
+describe('Continuous Polling (ChangeDetector)', () => {
+  let client: Interceptable;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    setGlobalDispatcher(agent);
+    client = agent.get(URL);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should trigger onChange when polling returns a new config (200 OK)', async () => {
+    const initialConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: {
+        host: 'initial-host',
+      },
+      createdAt: 0,
+    };
+
+    const newConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: {
+        host: 'updated-host',
+      },
+      createdAt: 1,
+    };
+
+    // Initial capabilities fetch
+    client
+      .intercept({ path: '/capabilities', method: 'GET' })
+      .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+
+    // Initial config fetch
+    client
+      .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
+      .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
+
+    const onChangeMock = vi.fn();
+
+    const configInstance = await config({
+      configName: 'name',
+      version: 1,
+      schema: commonDbPartialV1,
+      configServerUrl: URL,
+      localConfigPath: './tests/config',
+      pollIntervalMs: 10000,
+      onChange: onChangeMock,
+    });
+
+    expect(configInstance.get('host')).toBe('initial-host');
+    expect(onChangeMock).not.toHaveBeenCalled();
+
+    // Setup next poll response
+    client
+      .intercept({
+        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
+        method: 'GET',
+        headers: { 'if-none-match': 'etag-1' },
+      })
+      .reply(StatusCodes.OK, newConfigData, { headers: { etag: 'etag-2' } });
+
+    // Advance time to trigger poll
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'updated-host',
+      })
+    );
+  });
+
+  it('should not trigger onChange when polling returns 304 Not Modified', async () => {
+    const initialConfigData = {
+      configName: 'name',
+      schemaId: commonDbPartialV1.$id,
+      version: 1,
+      config: {
+        host: 'initial-host',
+      },
+      createdAt: 0,
+    };
+
+    // Initial capabilities fetch
+    client
+      .intercept({ path: '/capabilities', method: 'GET' })
+      .reply(StatusCodes.OK, { serverVersion: '2.0.0', schemasPackageVersion: '99.9.9', pubSubEnabled: false });
+
+    // Initial config fetch
+    client
+      .intercept({ path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`, method: 'GET' })
+      .reply(StatusCodes.OK, initialConfigData, { headers: { etag: 'etag-1' } });
+
+    const onChangeMock = vi.fn();
+
+    const configInstance = await config({
+      configName: 'name',
+      version: 1,
+      schema: commonDbPartialV1,
+      configServerUrl: URL,
+      localConfigPath: './tests/config',
+      pollIntervalMs: 10000,
+      onChange: onChangeMock,
+    });
+
+    // Setup next poll response (304)
+    client
+      .intercept({
+        path: `/config/name/1?shouldDereference=true&schemaId=${commonDbPartialV1.$id}`,
+        method: 'GET',
+        headers: { 'if-none-match': 'etag-1' },
+      })
+      .reply(StatusCodes.NOT_MODIFIED);
+
+    // Advance time to trigger poll
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+    expect(configInstance.get('host')).toBe('initial-host');
+  });
+});


### PR DESCRIPTION
This PR handles the poison-pill problem when the onChange throws an error and we need to keep the old config instead of setting the new invalid config.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |